### PR TITLE
Add utility code snippets and migrate ESM config

### DIFF
--- a/.vscode/react.code-snippets
+++ b/.vscode/react.code-snippets
@@ -1,0 +1,34 @@
+{
+  "Import module (example)": {
+    "scope": "javascriptreact,typescriptreact,typescript,javascript",
+    "prefix": "imp",
+    "description": "This import module",
+    "body": ["import {$2} from '$1'"],
+  },
+  "Export module (example)": {
+    "scope": "javascriptreact,typescriptreact,typescript,javascript",
+    "prefix": "exp",
+    "description": "This import module",
+    "body": ["export {$2} from '$1'"],
+  },
+  "Create function  default (example)": {
+    "scope": "javascriptreact,typescriptreact,typescript,javascript",
+    "prefix": "edf",
+    "description": "Create function export",
+    "body": [
+      "export default function ${1:${TM_FILENAME_BASE/(.*)/${1:/pascalcase}/}}(){",
+      "  return <${2:div}>$4</$2>",
+      "}",
+    ],
+  },
+  "Create function export (example)": {
+    "scope": "javascriptreact,typescriptreact,typescript,javascript",
+    "prefix": "ef",
+    "description": "Create function export",
+    "body": [
+      "export function ${1:${TM_FILENAME_BASE/(.*)/${1:/pascalcase}/}}(){",
+      "  return <${2:div}>$4</$2>",
+      "}",
+    ],
+  },
+}

--- a/postcss.config.js
+++ b/postcss.config.js
@@ -1,4 +1,4 @@
-module.exports = {
+export default {
   plugins: {
     tailwindcss: {},
     autoprefixer: {},

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -1,5 +1,5 @@
 /** @type {import('tailwindcss').Config} */
-module.exports = {
+export default {
   content: ["./index.html", "./src/**/*.{css,ts,tsx}"],
   theme: {
     extend: {},


### PR DESCRIPTION
Hello team,

Following the avant-garde nomenclature, I went to the trouble of changing CJS in the tailwindcss configuration files to ESM. Code snippets were also added to facilitate the creation of components and imports.

### Example code snippets

```jsx
// imp - Create the import structure
import {} from ''
```